### PR TITLE
Improve mobile viewport handling

### DIFF
--- a/game.js
+++ b/game.js
@@ -306,7 +306,18 @@ const cameraPresets = {
 };
 
 // Initialize the game when the DOM is loaded
-document.addEventListener('DOMContentLoaded', initGame);
+document.addEventListener('DOMContentLoaded', () => {
+  setViewportHeight();
+  initGame();
+});
+
+// Dynamically set a CSS variable for the viewport height to handle mobile
+function setViewportHeight() {
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+}
+
+window.addEventListener('resize', setViewportHeight);
 
 function initGame() {
   scene = new THREE.Scene();
@@ -1072,6 +1083,9 @@ function setCameraPreset(preset) {
 
   // Reset to center
   controls.target.set(0, 0, 0);
+
+  // Ensure the camera is looking at the center after repositioning
+  camera.lookAt(controls.target);
 
   controls.update();
 }

--- a/styles.css
+++ b/styles.css
@@ -78,7 +78,8 @@ body::after {
 #gameContainer {
   position: relative;
   width: 100%;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
+  min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
   background: radial-gradient(circle at center,


### PR DESCRIPTION
## Summary
- handle dynamic viewport height for Safari mobile
- keep camera centered after changing orientation

## Testing
- `npm test` *(fails: package.json not found)*